### PR TITLE
openapi.ymlの分割

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -59,5 +59,19 @@
     ]
     }%
 
-## 今後
-- `openapi.yaml`を分割して運用していく仕組みを検討
+## openapi.ymlのマージについて
+- [swagger-merger](https://www.npmjs.com/package/swagger-merger)を利用
+- 必要なもの
+  - node.jsとnpm(Win/Mac各環境に合わせて適当にインストールしておいてください)
+  - swagger-merger(ローカルインストール)
+
+## マージ実行方法
+    ./node_modules/.bin/swagger-merger -i swagger/spec/index.yml -o swagger/openapi.yml
+
+## 環境
+    okazaki@okazakinoiMac swagger_api_mock % node -v
+    v14.5.0
+    okazaki@okazakinoiMac swagger_api_mock % npm -v
+    6.14.5
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "fmtconv": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fmtconv/-/fmtconv-1.0.7.tgz",
+      "integrity": "sha512-2dj25b4aNiNotgq5u1jfodOt07hvMiYajry3xIjGauUTjo/DJGB1gALAYaMPLPL7DMv9ekCzIE5J53gevw5v6w==",
+      "requires": {
+        "commander": "^2.17.1",
+        "js-yaml": "^3.12.0"
+      }
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "swagger-merger": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/swagger-merger/-/swagger-merger-1.4.3.tgz",
+      "integrity": "sha512-ZGsz7n2uq/1pSUrY4owPYr3dTzH7u0P9laQzrh6QC7zl3uWjGHwkYgViJjr4rjdrfP44tkV3n8o8T6/F2aEc1g==",
+      "requires": {
+        "async": "^2.6.1",
+        "co": "^4.6.0",
+        "commander": "^2.17.1",
+        "fmtconv": "^1.0.6"
+      }
+    }
+  }
+}

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -1,68 +1,68 @@
 openapi: 3.0.0
 info:
-  description: "This is a sample server Petstore server.  You can find out more
-    about     Swagger at [http://swagger.io](http://swagger.io) or on
-    [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample,
-    you can use the api key `special-key` to test the
-    authorization     filters."
+  description: >-
+    This is a sample server Petstore server.  You can find out more about    
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).      For this sample, you can use the api
+    key `special-key` to test the authorization     filters.
   version: 1.0.0
   title: Swagger Petstore
-  termsOfService: http://swagger.io/terms/
+  termsOfService: 'http://swagger.io/terms/'
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: http://swagger.io
+      url: 'http://swagger.io'
   - name: store
     description: Access to Petstore orders
   - name: user
     description: Operations about user
     externalDocs:
       description: Find out more about our store
-      url: http://swagger.io
+      url: 'http://swagger.io'
 paths:
-  "/pet":
+  /pet:
     post:
       tags:
         - pet
       summary: Add a new pet to the store
-      description: ""
+      description: ''
       operationId: addPet
       requestBody:
-        $ref: "#/components/requestBodies/Pet"
+        $ref: '#/components/requestBodies/Pet'
       responses:
-        "405":
+        '405':
           description: Invalid input
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
+            - 'write:pets'
+            - 'read:pets'
     put:
       tags:
         - pet
       summary: Update an existing pet
-      description: ""
+      description: ''
       operationId: updatePet
       requestBody:
-        $ref: "#/components/requestBodies/Pet"
+        $ref: '#/components/requestBodies/Pet'
       responses:
-        "400":
+        '400':
           description: Invalid ID supplied
-        "404":
+        '404':
           description: Pet not found
-        "405":
+        '405':
           description: Validation exception
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
-  "/pet/findByStatus":
+            - 'write:pets'
+            - 'read:pets'
+  /pet/findByStatus:
     get:
       tags:
         - pet
@@ -85,32 +85,33 @@ paths:
                 - sold
               default: available
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/xml:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Pet"
+                  $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Pet"
-        "400":
+                  $ref: '#/components/schemas/Pet'
+        '400':
           description: Invalid status value
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
-  "/pet/findByTags":
+            - 'write:pets'
+            - 'read:pets'
+  /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: Muliple tags can be provided with comma separated strings.
-        Use         tag1, tag2, tag3 for testing.
+      description: >-
+        Muliple tags can be provided with comma separated strings. Use        
+        tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -123,27 +124,27 @@ paths:
             items:
               type: string
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/xml:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Pet"
+                  $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Pet"
-        "400":
+                  $ref: '#/components/schemas/Pet'
+        '400':
           description: Invalid tag value
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
+            - 'write:pets'
+            - 'read:pets'
       deprecated: true
-  "/pet/{petId}":
+  '/pet/{petId}':
     get:
       tags:
         - pet
@@ -159,18 +160,18 @@ paths:
             type: integer
             format: int64
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/xml:
               schema:
-                $ref: "#/components/schemas/Pet"
+                $ref: '#/components/schemas/Pet'
             application/json:
               schema:
-                $ref: "#/components/schemas/Pet"
-        "400":
+                $ref: '#/components/schemas/Pet'
+        '400':
           description: Invalid ID supplied
-        "404":
+        '404':
           description: Pet not found
       security:
         - api_key: []
@@ -178,7 +179,7 @@ paths:
       tags:
         - pet
       summary: Updates a pet in the store with form data
-      description: ""
+      description: ''
       operationId: updatePetWithForm
       parameters:
         - name: petId
@@ -201,17 +202,17 @@ paths:
                   description: Updated status of the pet
                   type: string
       responses:
-        "405":
+        '405':
           description: Invalid input
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
+            - 'write:pets'
+            - 'read:pets'
     delete:
       tags:
         - pet
       summary: Deletes a pet
-      description: ""
+      description: ''
       operationId: deletePet
       parameters:
         - name: api_key
@@ -227,20 +228,20 @@ paths:
             type: integer
             format: int64
       responses:
-        "400":
+        '400':
           description: Invalid ID supplied
-        "404":
+        '404':
           description: Pet not found
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
-  "/pet/{petId}/uploadImage":
+            - 'write:pets'
+            - 'read:pets'
+  '/pet/{petId}/uploadImage':
     post:
       tags:
         - pet
       summary: uploads an image
-      description: ""
+      description: ''
       operationId: uploadFile
       parameters:
         - name: petId
@@ -264,17 +265,17 @@ paths:
                   type: string
                   format: binary
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApiResponse"
+                $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - write:pets
-            - read:pets
-  "/store/inventory":
+            - 'write:pets'
+            - 'read:pets'
+  /store/inventory:
     get:
       tags:
         - store
@@ -282,7 +283,7 @@ paths:
       description: Returns a map of status codes to quantities
       operationId: getInventory
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/json:
@@ -293,39 +294,40 @@ paths:
                   format: int32
       security:
         - api_key: []
-  "/store/order":
+  /store/order:
     post:
       tags:
         - store
       summary: Place an order for a pet
-      description: ""
+      description: ''
       operationId: placeOrder
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Order"
+              $ref: '#/components/schemas/Order'
         description: order placed for purchasing the pet
         required: true
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/xml:
               schema:
-                $ref: "#/components/schemas/Order"
+                $ref: '#/components/schemas/Order'
             application/json:
               schema:
-                $ref: "#/components/schemas/Order"
-        "400":
+                $ref: '#/components/schemas/Order'
+        '400':
           description: Invalid Order
-  "/store/order/{orderId}":
+  '/store/order/{orderId}':
     get:
       tags:
         - store
       summary: Find purchase order by ID
-      description: For valid response try integer IDs with value >= 1 and <=
-        10.         Other values will generated exceptions
+      description: >-
+        For valid response try integer IDs with value >= 1 and <= 10.        
+        Other values will generated exceptions
       operationId: getOrderById
       parameters:
         - name: orderId
@@ -338,25 +340,26 @@ paths:
             minimum: 1
             maximum: 10
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/xml:
               schema:
-                $ref: "#/components/schemas/Order"
+                $ref: '#/components/schemas/Order'
             application/json:
               schema:
-                $ref: "#/components/schemas/Order"
-        "400":
+                $ref: '#/components/schemas/Order'
+        '400':
           description: Invalid ID supplied
-        "404":
+        '404':
           description: Order not found
     delete:
       tags:
         - store
       summary: Delete purchase order by ID
-      description: For valid response try integer IDs with positive integer
-        value.         Negative or non-integer values will generate API errors
+      description: >-
+        For valid response try integer IDs with positive integer value.        
+        Negative or non-integer values will generate API errors
       operationId: deleteOrder
       parameters:
         - name: orderId
@@ -368,11 +371,11 @@ paths:
             format: int64
             minimum: 1
       responses:
-        "400":
+        '400':
           description: Invalid ID supplied
-        "404":
+        '404':
           description: Order not found
-  "/user":
+  /user:
     post:
       tags:
         - user
@@ -383,42 +386,42 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/User"
+              $ref: '#/components/schemas/User'
         description: Created user object
         required: true
       responses:
         default:
           description: successful operation
-  "/user/createWithArray":
+  /user/createWithArray:
     post:
       tags:
         - user
       summary: Creates list of users with given input array
-      description: ""
+      description: ''
       operationId: createUsersWithArrayInput
       requestBody:
-        $ref: "#/components/requestBodies/UserArray"
+        $ref: '#/components/requestBodies/UserArray'
       responses:
         default:
           description: successful operation
-  "/user/createWithList":
+  /user/createWithList:
     post:
       tags:
         - user
       summary: Creates list of users with given input array
-      description: ""
+      description: ''
       operationId: createUsersWithListInput
       requestBody:
-        $ref: "#/components/requestBodies/UserArray"
+        $ref: '#/components/requestBodies/UserArray'
       responses:
         default:
           description: successful operation
-  "/user/login":
+  /user/login:
     get:
       tags:
         - user
       summary: Logs user into the system
-      description: ""
+      description: ''
       operationId: loginUser
       parameters:
         - name: username
@@ -434,7 +437,7 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: successful operation
           headers:
             X-Rate-Limit:
@@ -454,45 +457,45 @@ paths:
             application/json:
               schema:
                 type: string
-        "400":
+        '400':
           description: Invalid username/password supplied
-  "/user/logout":
+  /user/logout:
     get:
       tags:
         - user
       summary: Logs out current logged in user session
-      description: ""
+      description: ''
       operationId: logoutUser
       responses:
         default:
           description: successful operation
-  "/user/{username}":
+  '/user/{username}':
     get:
       tags:
         - user
       summary: Get user by user name
-      description: ""
+      description: ''
       operationId: getUserByName
       parameters:
         - name: username
           in: path
-          description: "The name that needs to be fetched. Use user1 for testing. "
+          description: 'The name that needs to be fetched. Use user1 for testing. '
           required: true
           schema:
             type: string
       responses:
-        "200":
+        '200':
           description: successful operation
           content:
             application/xml:
               schema:
-                $ref: "#/components/schemas/User"
+                $ref: '#/components/schemas/User'
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
-        "400":
+                $ref: '#/components/schemas/User'
+        '400':
           description: Invalid username supplied
-        "404":
+        '404':
           description: User not found
     put:
       tags:
@@ -511,13 +514,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/User"
+              $ref: '#/components/schemas/User'
         description: Updated user object
         required: true
       responses:
-        "400":
+        '400':
           description: Invalid user supplied
-        "404":
+        '404':
           description: User not found
     delete:
       tags:
@@ -533,16 +536,16 @@ paths:
           schema:
             type: string
       responses:
-        "400":
+        '400':
           description: Invalid username supplied
-        "404":
+        '404':
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: http://swagger.io
+  url: 'http://swagger.io'
 servers:
-  - url: https://petstore.swagger.io/v2
-  - url: http://petstore.swagger.io/v2
+  - url: 'https://petstore.swagger.io/v2'
+  - url: 'http://petstore.swagger.io/v2'
 components:
   requestBodies:
     UserArray:
@@ -551,17 +554,17 @@ components:
           schema:
             type: array
             items:
-              $ref: "#/components/schemas/User"
+              $ref: '#/components/schemas/User'
       description: List of user object
       required: true
     Pet:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Pet"
+            $ref: '#/components/schemas/Pet'
         application/xml:
           schema:
-            $ref: "#/components/schemas/Pet"
+            $ref: '#/components/schemas/Pet'
       description: Pet object that needs to be added to the store
       required: true
   securitySchemes:
@@ -569,10 +572,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          authorizationUrl: 'http://petstore.swagger.io/oauth/dialog'
           scopes:
-            write:pets: modify pets in your account
-            read:pets: read your pets
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -659,7 +662,7 @@ components:
           type: integer
           format: int64
         category:
-          $ref: "#/components/schemas/Category"
+          $ref: '#/components/schemas/Category'
         name:
           type: string
           example: doggie
@@ -676,7 +679,7 @@ components:
             name: tag
             wrapped: true
           items:
-            $ref: "#/components/schemas/Tag"
+            $ref: '#/components/schemas/Tag'
         status:
           type: string
           description: pet status in the store

--- a/swagger/spec/components/index.yml
+++ b/swagger/spec/components/index.yml
@@ -1,0 +1,17 @@
+requestBodies:
+  $ref: "./request_bodies/index.yml"
+securitySchemes:
+  petstore_auth:
+    type: oauth2
+    flows:
+      implicit:
+        authorizationUrl: http://petstore.swagger.io/oauth/dialog
+        scopes:
+          write:pets: modify pets in your account
+          read:pets: read your pets
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+schemas:
+  $ref: "./schemas/index.yml"

--- a/swagger/spec/components/request_bodies/index.yml
+++ b/swagger/spec/components/request_bodies/index.yml
@@ -1,0 +1,4 @@
+UserArray:
+  $ref: "./user_array.yml"
+Pet:
+  $ref: "./pet.yml"

--- a/swagger/spec/components/request_bodies/pet.yml
+++ b/swagger/spec/components/request_bodies/pet.yml
@@ -1,0 +1,9 @@
+content:
+  application/json:
+    schema:
+      $ref: "#/components/schemas/Pet"
+  application/xml:
+    schema:
+      $ref: "#/components/schemas/Pet"
+description: Pet object that needs to be added to the store
+required: true

--- a/swagger/spec/components/request_bodies/user_array.yml
+++ b/swagger/spec/components/request_bodies/user_array.yml
@@ -1,0 +1,8 @@
+content:
+  application/json:
+    schema:
+      type: array
+      items:
+        $ref: "#/components/schemas/User"
+description: List of user object
+required: true

--- a/swagger/spec/components/schemas/api_response.yml
+++ b/swagger/spec/components/schemas/api_response.yml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  code:
+    type: integer
+    format: int32
+  type:
+    type: string
+  message:
+    type: string

--- a/swagger/spec/components/schemas/category.yml
+++ b/swagger/spec/components/schemas/category.yml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+xml:
+  name: Category

--- a/swagger/spec/components/schemas/index.yml
+++ b/swagger/spec/components/schemas/index.yml
@@ -1,0 +1,12 @@
+Order:
+  $ref: "./order.yml"
+Category:
+  $ref: "./category.yml"
+User:
+  $ref: "./user.yml"
+Tag:
+  $ref: "./tag.yml"
+Pet:
+  $ref: "./pet.yml"
+ApiResponse:
+  $ref: "./api_response.yml"

--- a/swagger/spec/components/schemas/order.yml
+++ b/swagger/spec/components/schemas/order.yml
@@ -1,0 +1,26 @@
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  petId:
+    type: integer
+    format: int64
+  quantity:
+    type: integer
+    format: int32
+  shipDate:
+    type: string
+    format: date-time
+  status:
+    type: string
+    description: Order Status
+    enum:
+      - placed
+      - approved
+      - delivered
+  complete:
+    type: boolean
+    default: false
+xml:
+  name: Order

--- a/swagger/spec/components/schemas/pet.yml
+++ b/swagger/spec/components/schemas/pet.yml
@@ -1,0 +1,36 @@
+type: object
+required:
+  - name
+  - photoUrls
+properties:
+  id:
+    type: integer
+    format: int64
+  category:
+    $ref: "#/components/schemas/Category"
+  name:
+    type: string
+    example: doggie
+  photoUrls:
+    type: array
+    xml:
+      name: photoUrl
+      wrapped: true
+    items:
+      type: string
+  tags:
+    type: array
+    xml:
+      name: tag
+      wrapped: true
+    items:
+      $ref: "#/components/schemas/Tag"
+  status:
+    type: string
+    description: pet status in the store
+    enum:
+      - available
+      - pending
+      - sold
+xml:
+  name: Pet

--- a/swagger/spec/components/schemas/tag.yml
+++ b/swagger/spec/components/schemas/tag.yml
@@ -1,0 +1,9 @@
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+xml:
+  name: Tag

--- a/swagger/spec/components/schemas/user.yml
+++ b/swagger/spec/components/schemas/user.yml
@@ -1,0 +1,23 @@
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  username:
+    type: string
+  firstName:
+    type: string
+  lastName:
+    type: string
+  email:
+    type: string
+  password:
+    type: string
+  phone:
+    type: string
+  userStatus:
+    type: integer
+    format: int32
+    description: User Status
+xml:
+  name: User

--- a/swagger/spec/index.yml
+++ b/swagger/spec/index.yml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  description: "This is a sample server Petstore server.  You can find out more
+    about     Swagger at [http://swagger.io](http://swagger.io) or on
+    [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample,
+    you can use the api key `special-key` to test the
+    authorization     filters."
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  $ref: "./paths/index.yml"
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: https://petstore.swagger.io/v2
+  - url: http://petstore.swagger.io/v2
+components:
+  $ref: "./components/index.yml"

--- a/swagger/spec/paths/index.yml
+++ b/swagger/spec/paths/index.yml
@@ -1,0 +1,28 @@
+"/pet":
+  $ref: "./pet/pet.yml"
+"/pet/findByStatus":
+  $ref: "./pet/find_by_status.yml"
+"/pet/findByTags":
+  $ref: "./pet/find_by_tags.yml"
+"/pet/{petId}":
+  $ref: "./pet/find_by_id.yml"
+"/pet/{petId}/uploadImage":
+  $ref: "./pet/upload_image.yml"
+"/store/inventory":
+  $ref: "./store/inventory.yml"
+"/store/order":
+  $ref: "./store/order.yml"
+"/store/order/{orderId}":
+  $ref: "./store/order_by_id.yml"
+"/user":
+  $ref: "./user/create_user.yml"
+"/user/createWithArray":
+  $ref: "./user/create_with_array.yml"
+"/user/createWithList":
+  $ref: "./user/create_with_list.yml"
+"/user/login":
+  $ref: "./user/login.yml"
+"/user/logout":
+  $ref: "./user/logout.yml"
+"/user/{username}":
+  $ref: "./user/user.yml"

--- a/swagger/spec/paths/pet/find_by_id.yml
+++ b/swagger/spec/paths/pet/find_by_id.yml
@@ -1,0 +1,91 @@
+get:
+  tags:
+    - pet
+  summary: Find pet by ID
+  description: Returns a single pet
+  operationId: getPetById
+  parameters:
+    - name: petId
+      in: path
+      description: ID of pet to return
+      required: true
+      schema:
+        type: integer
+        format: int64
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+    "400":
+      description: Invalid ID supplied
+    "404":
+      description: Pet not found
+  security:
+    - api_key: []
+post:
+  tags:
+    - pet
+  summary: Updates a pet in the store with form data
+  description: ""
+  operationId: updatePetWithForm
+  parameters:
+    - name: petId
+      in: path
+      description: ID of pet that needs to be updated
+      required: true
+      schema:
+        type: integer
+        format: int64
+  requestBody:
+    content:
+      application/x-www-form-urlencoded:
+        schema:
+          type: object
+          properties:
+            name:
+              description: Updated name of the pet
+              type: string
+            status:
+              description: Updated status of the pet
+              type: string
+  responses:
+    "405":
+      description: Invalid input
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets
+delete:
+  tags:
+    - pet
+  summary: Deletes a pet
+  description: ""
+  operationId: deletePet
+  parameters:
+    - name: api_key
+      in: header
+      required: false
+      schema:
+        type: string
+    - name: petId
+      in: path
+      description: Pet id to delete
+      required: true
+      schema:
+        type: integer
+        format: int64
+  responses:
+    "400":
+      description: Invalid ID supplied
+    "404":
+      description: Pet not found
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets

--- a/swagger/spec/paths/pet/find_by_status.yml
+++ b/swagger/spec/paths/pet/find_by_status.yml
@@ -1,0 +1,41 @@
+get:
+  tags:
+    - pet
+  summary: Finds Pets by status
+  description: Multiple status values can be provided with comma separated strings
+  operationId: findPetsByStatus
+  parameters:
+    - name: status
+      in: query
+      description: Status values that need to be considered for filter
+      required: true
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - available
+            - pending
+            - sold
+          default: available
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/xml:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Pet"
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Pet"
+    "400":
+      description: Invalid status value
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets

--- a/swagger/spec/paths/pet/find_by_tags.yml
+++ b/swagger/spec/paths/pet/find_by_tags.yml
@@ -1,0 +1,38 @@
+get:
+  tags:
+    - pet
+  summary: Finds Pets by tags
+  description: Muliple tags can be provided with comma separated strings.
+    Use         tag1, tag2, tag3 for testing.
+  operationId: findPetsByTags
+  parameters:
+    - name: tags
+      in: query
+      description: Tags to filter by
+      required: true
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/xml:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Pet"
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Pet"
+    "400":
+      description: Invalid tag value
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets
+  deprecated: true

--- a/swagger/spec/paths/pet/pet.yml
+++ b/swagger/spec/paths/pet/pet.yml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - pet
+  summary: Add a new pet to the store
+  description: ""
+  operationId: addPet
+  requestBody:
+    $ref: "#/components/requestBodies/Pet"
+  responses:
+    "405":
+      description: Invalid input
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets
+put:
+  tags:
+    - pet
+  summary: Update an existing pet
+  description: ""
+  operationId: updatePet
+  requestBody:
+    $ref: "#/components/requestBodies/Pet"
+  responses:
+    "400":
+      description: Invalid ID supplied
+    "404":
+      description: Pet not found
+    "405":
+      description: Validation exception
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets

--- a/swagger/spec/paths/pet/upload_image.yml
+++ b/swagger/spec/paths/pet/upload_image.yml
@@ -1,0 +1,38 @@
+post:
+  tags:
+    - pet
+  summary: uploads an image
+  description: ""
+  operationId: uploadFile
+  parameters:
+    - name: petId
+      in: path
+      description: ID of pet to update
+      required: true
+      schema:
+        type: integer
+        format: int64
+  requestBody:
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          properties:
+            additionalMetadata:
+              description: Additional data to pass to server
+              type: string
+            file:
+              description: file to upload
+              type: string
+              format: binary
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiResponse"
+  security:
+    - petstore_auth:
+        - write:pets
+        - read:pets

--- a/swagger/spec/paths/store/inventory.yml
+++ b/swagger/spec/paths/store/inventory.yml
@@ -1,0 +1,18 @@
+get:
+  tags:
+    - store
+  summary: Returns pet inventories by status
+  description: Returns a map of status codes to quantities
+  operationId: getInventory
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+  security:
+    - api_key: []

--- a/swagger/spec/paths/store/order.yml
+++ b/swagger/spec/paths/store/order.yml
@@ -1,0 +1,25 @@
+post:
+  tags:
+    - store
+  summary: Place an order for a pet
+  description: ""
+  operationId: placeOrder
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/Order"
+    description: order placed for purchasing the pet
+    required: true
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Order"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Order"
+    "400":
+      description: Invalid Order

--- a/swagger/spec/paths/store/order_by_id.yml
+++ b/swagger/spec/paths/store/order_by_id.yml
@@ -1,0 +1,52 @@
+get:
+  tags:
+    - store
+  summary: Find purchase order by ID
+  description: For valid response try integer IDs with value >= 1 and <=
+    10.         Other values will generated exceptions
+  operationId: getOrderById
+  parameters:
+    - name: orderId
+      in: path
+      description: ID of pet that needs to be fetched
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+        maximum: 10
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Order"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Order"
+    "400":
+      description: Invalid ID supplied
+    "404":
+      description: Order not found
+delete:
+  tags:
+    - store
+  summary: Delete purchase order by ID
+  description: For valid response try integer IDs with positive integer
+    value.         Negative or non-integer values will generate API errors
+  operationId: deleteOrder
+  parameters:
+    - name: orderId
+      in: path
+      description: ID of the order that needs to be deleted
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+  responses:
+    "400":
+      description: Invalid ID supplied
+    "404":
+      description: Order not found

--- a/swagger/spec/paths/user/create_user.yml
+++ b/swagger/spec/paths/user/create_user.yml
@@ -1,0 +1,16 @@
+post:
+  tags:
+    - user
+  summary: Create user
+  description: This can only be done by the logged in user.
+  operationId: createUser
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/User"
+    description: Created user object
+    required: true
+  responses:
+    default:
+      description: successful operation

--- a/swagger/spec/paths/user/create_with_array.yml
+++ b/swagger/spec/paths/user/create_with_array.yml
@@ -1,0 +1,11 @@
+post:
+  tags:
+    - user
+  summary: Creates list of users with given input array
+  description: ""
+  operationId: createUsersWithArrayInput
+  requestBody:
+    $ref: "#/components/requestBodies/UserArray"
+  responses:
+    default:
+      description: successful operation

--- a/swagger/spec/paths/user/create_with_list.yml
+++ b/swagger/spec/paths/user/create_with_list.yml
@@ -1,0 +1,11 @@
+post:
+  tags:
+    - user
+  summary: Creates list of users with given input array
+  description: ""
+  operationId: createUsersWithListInput
+  requestBody:
+    $ref: "#/components/requestBodies/UserArray"
+  responses:
+    default:
+      description: successful operation

--- a/swagger/spec/paths/user/login.yml
+++ b/swagger/spec/paths/user/login.yml
@@ -1,0 +1,42 @@
+get:
+  tags:
+    - user
+  summary: Logs user into the system
+  description: ""
+  operationId: loginUser
+  parameters:
+    - name: username
+      in: query
+      description: The user name for login
+      required: true
+      schema:
+        type: string
+    - name: password
+      in: query
+      description: The password for login in clear text
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: successful operation
+      headers:
+        X-Rate-Limit:
+          description: calls per hour allowed by the user
+          schema:
+            type: integer
+            format: int32
+        X-Expires-After:
+          description: date in UTC when token expires
+          schema:
+            type: string
+            format: date-time
+      content:
+        application/xml:
+          schema:
+            type: string
+        application/json:
+          schema:
+            type: string
+    "400":
+      description: Invalid username/password supplied

--- a/swagger/spec/paths/user/logout.yml
+++ b/swagger/spec/paths/user/logout.yml
@@ -1,0 +1,9 @@
+get:
+  tags:
+    - user
+  summary: Logs out current logged in user session
+  description: ""
+  operationId: logoutUser
+  responses:
+    default:
+      description: successful operation

--- a/swagger/spec/paths/user/user.yml
+++ b/swagger/spec/paths/user/user.yml
@@ -1,0 +1,70 @@
+get:
+  tags:
+    - user
+  summary: Get user by user name
+  description: ""
+  operationId: getUserByName
+  parameters:
+    - name: username
+      in: path
+      description: "The name that needs to be fetched. Use user1 for testing. "
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: successful operation
+      content:
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/User"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/User"
+    "400":
+      description: Invalid username supplied
+    "404":
+      description: User not found
+put:
+  tags:
+    - user
+  summary: Updated user
+  description: This can only be done by the logged in user.
+  operationId: updateUser
+  parameters:
+    - name: username
+      in: path
+      description: name that need to be updated
+      required: true
+      schema:
+        type: string
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/User"
+    description: Updated user object
+    required: true
+  responses:
+    "400":
+      description: Invalid user supplied
+    "404":
+      description: User not found
+delete:
+  tags:
+    - user
+  summary: Delete user
+  description: This can only be done by the logged in user.
+  operationId: deleteUser
+  parameters:
+    - name: username
+      in: path
+      description: The name that needs to be deleted
+      required: true
+      schema:
+        type: string
+  responses:
+    "400":
+      description: Invalid username supplied
+    "404":
+      description: User not found


### PR DESCRIPTION
# 概要
* 表題の通り

# やっていること
* `swagger/openapi.yml` を `swagger/spec` ディレクトリ配下に複数のファイルにして分割
* 以下を中心に切り出した
  * `paths` APIのエンドポイントと仕様をサービス単位でディレクトリ分けし、1API1ファイルになるように分割
  * `components` スキーマとリクエストボディを1オブジェクト1ファイルになるように分割

# 動作確認内容
**参考程度に**
* ブランチを手元に持ってきて `openapi.yml` を削除してみる
* READMEを参考に手元でswagger-mergerを実行してみて、openapi.ymlが作成される
* マージしたopenapi.ymlを元に各コンテナを起動してみて、swagger UI、Redoc、APIモックが正常に動作する